### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/SpringBootSecurityJwt/src/main/java/com/tistory/heowc/auth/jwt/JwtUserDetailsService.java
+++ b/SpringBootSecurityJwt/src/main/java/com/tistory/heowc/auth/jwt/JwtUserDetailsService.java
@@ -7,9 +7,9 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class JwtUserDetailsService implements UserDetailsService {
 
     @Override


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code. 

A Spring bean in the service layer should be annotated using @Service instead of @Component annotation.
@Service annotation is a specialization of @Component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @Service is a better choice.