### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/SpringBootSecurityJwt/src/main/java/com/tistory/heowc/auth/ajax/AjaxUserDetailsService.java
+++ b/SpringBootSecurityJwt/src/main/java/com/tistory/heowc/auth/ajax/AjaxUserDetailsService.java
@@ -8,9 +8,9 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class AjaxUserDetailsService implements UserDetailsService {
 
 	@Autowired


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code.

A Spring bean in the service layer should be annotated using @service instead of @component annotation.
@service annotation is a specialization of @component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @service is a better choice.